### PR TITLE
ci: add account age gating workflow

### DIFF
--- a/.github/scripts/check_account_age.js
+++ b/.github/scripts/check_account_age.js
@@ -1,0 +1,66 @@
+// Auto-close issues/PRs from accounts younger than a minimum age.
+//
+// Inputs:
+//   `MIN_AGE_DAYS`: minimum account age in days (default: 30)
+
+module.exports = async ({ github, context }) => {
+  const minAgeDays = parseInt(process.env.MIN_AGE_DAYS || "30", 10);
+
+  const isPR = !!context.payload.pull_request;
+  const target = isPR ? context.payload.pull_request : context.payload.issue;
+  const author = target.user.login;
+
+  let user;
+  try {
+    ({ data: user } = await github.rest.users.getByUsername({
+      username: author,
+    }));
+  } catch {
+    console.log(`Could not fetch user @${author}, skipping`);
+    return;
+  }
+
+  const createdAt = new Date(user.created_at);
+  const now = new Date();
+  const ageDays = Math.floor((now - createdAt) / (1000 * 60 * 60 * 24));
+
+  console.log(`@${author} created ${user.created_at} (${ageDays}d ago)`);
+
+  if (ageDays >= minAgeDays) {
+    console.log(`Account age OK (${ageDays}d >= ${minAgeDays}d)`);
+    return;
+  }
+
+  console.log(`Account too new (${ageDays}d < ${minAgeDays}d)`);
+
+  const noun = isPR ? "pull request" : "issue";
+  const body =
+    `This ${noun} has been automatically closed because ` +
+    `@${author}'s account is less than ${minAgeDays} days old ` +
+    `(created ${ageDays} days ago). This is an automated policy ` +
+    `to reduce spam. If this was a mistake, please leave a comment ` +
+    `explaining why, and a maintainer will take a look.`;
+
+  await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number: target.number,
+    body,
+  });
+
+  if (isPR) {
+    await github.rest.pulls.update({
+      ...context.repo,
+      pull_number: target.number,
+      state: "closed",
+    });
+  } else {
+    await github.rest.issues.update({
+      ...context.repo,
+      issue_number: target.number,
+      state: "closed",
+      state_reason: "not_planned",
+    });
+  }
+
+  console.log(`Closed ${noun} #${target.number}`);
+};

--- a/.github/workflows/check-account-age.yml
+++ b/.github/workflows/check-account-age.yml
@@ -1,0 +1,34 @@
+name: Check account age
+
+on:
+  workflow_call:
+    inputs:
+      min-age-days:
+        description: Minimum account age in days
+        type: number
+        default: 30
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout script
+        uses: actions/checkout@v6
+        with:
+          repository: tree-sitter/.github
+          sparse-checkout: .github/scripts/check_account_age.js
+          sparse-checkout-cone-mode: false
+
+      - name: Check account age
+        uses: actions/github-script@v8
+        env:
+          MIN_AGE_DAYS: ${{ inputs.min-age-days }}
+        with:
+          script: |
+            const script = require('./.github/scripts/check_account_age.js')
+            await script({github, context})

--- a/workflow-templates/check-account-age.properties.json
+++ b/workflow-templates/check-account-age.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Check account age",
+  "description": "Auto-close issues/PRs from accounts less than 30 days old.",
+  "categories": ["moderation"]
+}

--- a/workflow-templates/check-account-age.yml
+++ b/workflow-templates/check-account-age.yml
@@ -1,0 +1,13 @@
+name: Check account age
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  check:
+    uses: tree-sitter/.github/.github/workflows/check-account-age.yml@master
+    with:
+      min-age-days: 30


### PR DESCRIPTION
Over half of our spam PRs and issues come from accounts that were under 30 days old at the time of the spam being submitted, so this workflow would help us quite a bit in auto-closing spam.